### PR TITLE
Diepontladingsbeveiliging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "files.associations": {
+        "cmath": "cpp",
+        "cstdarg": "cpp",
+        "cstdint": "cpp",
+        "cstdio": "cpp",
+        "cstdlib": "cpp",
+        "exception": "cpp",
+        "algorithm": "cpp",
+        "random": "cpp",
+        "type_traits": "cpp",
+        "utility": "cpp",
+        "initializer_list": "cpp",
+        "limits": "cpp",
+        "typeinfo": "cpp"
+    }
+}

--- a/Hoverbaas/Hoverbaas.ino
+++ b/Hoverbaas/Hoverbaas.ino
@@ -1,7 +1,7 @@
 #include "Adafruit_VL53L0X.h"
 #include <Wire.h>
 #include <MPU9250_asukiaaa.h>
- 
+#include "regelaar23.h"
 
 #define maxon1_pin 11
 #define maxon2_pin 9
@@ -154,6 +154,9 @@ void loop() {
   // Serial.println("UPDATING hardware");
   update_hardware();
 
+
+  r23 regelaar23(3, 2, 0.1);
+
   switch(state.stateNr){
   case 0:
   //start-up
@@ -186,6 +189,8 @@ void loop() {
   break;
   case 23:
   //90 graden rotatie
+    float dt = 0.01 //TODO ergens vandaan halen 
+    r23.step(state.gyroDir, 90/180*3.14, dt, set_state.set_motor_one_force, set_state.set_motor_two_force);
   break;
   case 24:
   //rpi

--- a/Hoverbaas/regelaar23.h
+++ b/Hoverbaas/regelaar23.h
@@ -1,0 +1,45 @@
+#ifndef REGELAAR23_H
+#define REGELAAR23_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+// struct {
+//   //4 bytes
+//   int stateNr = 0;
+//   //4 bytes
+//   float gyroDir;
+//   float motor_one_force;
+//   float motor_two_force;
+//   float motor_middle_force;
+//   float current;
+//   // 2 bytes
+//   uint16_t tof_front;
+//   uint16_t tof_right_front;
+//   uint16_t tof_right_back;
+//   //1 byte
+//   bool blowers;
+// } state;
+
+class regelaar {
+public:
+    double Kp;
+    double Kd;
+    double Ki;
+    double error_last;
+    double error_sum;
+    float basis_kracht;
+    float max_krachtverschil;
+
+    regelaar(double Kp = 0.0, double Kd = 0.0, double Ki = 0.0);
+    virtual ~regelaar() = default;
+};
+
+class regelaar23 : public regelaar {
+public:
+    regelaar23(double Kp = 0.0, double Kd = 0.0, double Ki = 0.0);
+    void step(float theta, float setpoint, float dt, float& m1_force, float& m2_force); // theta, m1 en m2 van state, m1&m2 by reference
+};
+
+#endif // REGELAAR23_H

--- a/Hoverbaas/regelaar23.ino
+++ b/Hoverbaas/regelaar23.ino
@@ -1,0 +1,38 @@
+#include "regelaar23.h"
+#include <algorithm>
+#include <cmath>
+
+regelaar::regelaar(double Kp, double Kd, double Ki)
+    : Kp(Kp), Kd(Kd), Ki(Ki), error_last(0.0), error_sum(0.0), basis_kracht(0.3), max_krachtverschil(0.3) {}
+
+regelaar23::regelaar23(double Kp, double Kd, double Ki)
+    : regelaar(Kp, Kd, Ki) {}
+
+void regelaar23::step(float theta, float setpoint, float dt, float& m1_force, float& m2_force) { // theta, m1 en m2  van state, m1&m2 by reference
+    double pi = 3.14159265358979323846; // TODO ergens anders definiëren
+    double error_new = std::fmod((setpoint - theta + pi), (2 * pi)) - pi;
+    double d_error = (error_new - this->error_last) / dt;
+
+    float m1 = error_new * this->Kp + d_error * this->Kd + this->error_sum * this->Ki;
+    float m2 = (error_new * this->Kp + d_error * this->Kd + this->error_sum * this->Ki) * -1;
+    m1 = std::max(0.0, std::min(m1, static_cast<double>(this->basis_kracht + this->max_krachtverschil)));
+    m2 = std::max(0.0, std::min(m2, static_cast<double>(this->basis_kracht + this->max_krachtverschil)));
+
+    // Anti integrator-windup for m1
+    if (m1 < ((this->basis_kracht + this->max_krachtverschil) / 2.0)) {
+        this->error_sum += error_new * dt;
+    }
+    // Anti integrator-windup for m2
+    if (m2 < ((this->basis_kracht + this->max_krachtverschil) / 2.0)) {
+        this->error_sum += error_new * dt;
+    }
+
+    // oude anti-windup
+    // if (!(m1 >= (this->basis_kracht + this->max_krachtverschil))) { // anti integrator-windup
+    //     this->error_sum += error_new * dt;
+    // }
+    // this->error_last = error_new;
+
+    m1_force = m1;
+    m2_force = m2;
+}


### PR DESCRIPTION
- `#defines` voor relais 1 & 2 op `D3`, `D4` aan de hand van diagram PCB.
- Interrupt `INT0` op `D2` toegevoegd voor diepontladingsbeveiliging.
- `set_state.set_blowers` zet nu pin `D3` hoog/laag i.p.v. `D2`, omdat `D2` voor de interrupt gebruikt wordt.

![image](https://github.com/user-attachments/assets/b11ce5a4-2fe1-40ae-9479-cf3c81dca14f)